### PR TITLE
Fix crash when "window" is undefined

### DIFF
--- a/browser.mjs
+++ b/browser.mjs
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-export const performance = typeof window === 'undefined' ? null : typeof window.performance !== 'undefined' && window.performance || null;
+export const performance = typeof window === 'undefined' ? null : (typeof window.performance !== 'undefined' && window.performance) || null
 
 const isoCrypto = typeof crypto === 'undefined' ? null : crypto
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-export const performance = typeof window !== 'undefined' && typeof window.performance === 'undefined' ? null : window.performance
+export const performance = typeof window === 'undefined' ? null : typeof window.performance !== 'undefined' && window.performance
 
 const isoCrypto = typeof crypto === 'undefined' ? null : crypto
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-export const performance = typeof window === 'undefined' ? null : typeof window.performance !== 'undefined' && window.performance
+export const performance = typeof window === 'undefined' ? null : typeof window.performance !== 'undefined' && window.performance || null;
 
 const isoCrypto = typeof crypto === 'undefined' ? null : crypto
 


### PR DESCRIPTION
I'm loading Yjs in a web worker, using the latest version I was getting a crash that `window is not defined`, looks like a minor logic bug. If window is `undefined` then it will fall into the else case in that ternary.

Easiest way to reproduce is to just run it in node (where window is not defined):
```
❯ node
Welcome to Node.js v15.6.0.
Type ".help" for more information.
> const performance = typeof window !== 'undefined' && typeof window.performance === 'undefined' ? null : window.performance
Uncaught ReferenceError: window is not defined
```

Output with my fix:
```
❯ node
Welcome to Node.js v15.6.0.
Type ".help" for more information.
> performance = typeof window === 'undefined' ? null : (typeof window.performance !== 'undefined' && window.performance) || null
null
> window = {}
{}
> performance = typeof window === 'undefined' ? null : (typeof window.performance !== 'undefined' && window.performance) || null
null
> window.performance = 1
1
> performance = typeof window === 'undefined' ? null : (typeof window.performance !== 'undefined' && window.performance) || null
1
> 🎉
``` 

lmk if theres something I missed or if you have a testing framework you want me to write a test of this in. 🍻